### PR TITLE
Update TuningDateField.java

### DIFF
--- a/tuning-datefield/src/main/java/org/vaadin/addons/tuningdatefield/TuningDateField.java
+++ b/tuning-datefield/src/main/java/org/vaadin/addons/tuningdatefield/TuningDateField.java
@@ -831,7 +831,7 @@ public class TuningDateField extends AbstractField<LocalDate> implements BlurNot
 
             String calendarItemContent = null;
             if (cellItemCustomizer != null) {
-                calendarItemContent = cellItemCustomizer.renderMonth(currentYearMonthValue, this);
+                calendarItemContent = cellItemCustomizer.renderMonth(month, this);
             }
             // fallback to default value
             if (calendarItemContent == null) {


### PR DESCRIPTION
Using currentYearMonthValue instead of month makes no sense and cause renderMonth to fail in the cellItemCustomizer